### PR TITLE
Update Go toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module fynemd
 
-go 1.24.3
+go 1.22
 
 require (
 	fyne.io/fyne/v2 v2.6.1


### PR DESCRIPTION
## Summary
- set the module's Go version directive to 1.22, which is supported by Fyne

## Testing
- `go mod tidy` *(fails: unable to download modules due to 403 from proxy)*
- `go run .` *(interrupted: application starts but requires a GUI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cedd0bd3a083319c288ce80b71212a